### PR TITLE
feature: `unregister` metric dynamically (`rpc` call)

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -245,8 +245,8 @@ func (p *Plugin) Name() string {
 
 // RPC interface satisfaction
 func (p *Plugin) RPC() any {
-	return &rpcServer{
-		svc: p,
+	return &rpc{
+		p:   p,
 		log: p.log,
 	}
 }


### PR DESCRIPTION
# Reason for This PR

- Unregister previously registered collector.

## Description of Changes

- New `RPC` call receives a collector name (string) to unregister it from the RR and Prometheus registrants.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
