### PR TITLE
feat: Add JSON schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -65,13 +65,26 @@
           "then": {
             "properties": {
               "buckets": {
-                "description": "The collector's buckets for the histogram type.",
+                "description": "The collector's buckets for the histogram type. Values must be in increasing order. The +Inf bucket is added implicitly at the end. If this array is undefined or empty, the default buckets are used.",
                 "type": "array",
-                "minItems": 1,
                 "uniqueItems": true,
                 "items": {
+                  "minimum": 0,
                   "type": "number"
-                }
+                },
+                "default": [
+                  0.005,
+                  0.01,
+                  0.025,
+                  0.05,
+                  0.1,
+                  0.25,
+                  0.5,
+                  1,
+                  2.5,
+                  5,
+                  10
+                ]
               }
             }
           },

--- a/schema.json
+++ b/schema.json
@@ -18,7 +18,7 @@
       "additionalProperties": false,
       "minProperties": 1,
       "patternProperties": {
-        "^[a-zA-Z0-9._-]+$": {
+        "^[a-zA-Z_:][a-zA-Z0-9_:]*$": {
           "type": "object",
           "description": "The metrics to set up in Prometheus. See https://prometheus.io/docs/guides/go-application/ for details.",
           "properties": {
@@ -44,12 +44,12 @@
               "description": "The collector's help message."
             },
             "labels": {
-              "description": "The collector's metrics labels.",
+              "description": "The collector's metrics labels. These must be in the format supported by Prometheus. See https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels",
               "type": "array",
               "minItems": 1,
               "items": {
                 "type": "string",
-                "minLength": 1
+                "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
               }
             },
             "buckets": {

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,79 @@
+{
+  "$id": "https://raw.githubusercontent.com/roadrunner-server/metrics/refs/heads/master/schema.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "description": "All the valid configuration parameters for the Prometheus Metrics plugin for RoadRunner.",
+  "type": "object",
+  "title": "roadrunner-metrics",
+  "additionalProperties": false,
+  "properties": {
+    "address": {
+      "description": "Prometheus client address (path /metrics is appended automatically).",
+      "type": "string",
+      "default": "127.0.0.1:2112",
+      "minLength": 1
+    },
+    "collect": {
+      "description": "Application-specific metrics (published using an RPC connection to the server).",
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "type": "object",
+          "description": "The metrics to set up in Prometheus. See https://prometheus.io/docs/guides/go-application/ for details.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "histogram",
+                "gauge",
+                "counter",
+                "summary"
+              ]
+            },
+            "namespace": {
+              "type": "string",
+              "description": "The collector's namespace."
+            },
+            "subsystem": {
+              "type": "string",
+              "description": "The collector's subsystem."
+            },
+            "help": {
+              "type": "string",
+              "description": "The collector's help message."
+            },
+            "labels": {
+              "description": "The collector's metrics labels.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "buckets": {
+              "description": "The colletor's buckets for the histogram type.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "number"
+              }
+            },
+            "objectives": {
+              "description": "The collector's objectives for the summary type.",
+              "type": "object",
+              "minProperties": 1,
+              "additionalProperties": false,
+              "patternProperties": {
+                "^-?[0-9]+(\\.[0-9]+)?$": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema.json
+++ b/schema.json
@@ -21,8 +21,10 @@
         "^[a-zA-Z_:][a-zA-Z0-9_:]*$": {
           "type": "object",
           "description": "The metrics to set up in Prometheus. See https://prometheus.io/docs/guides/go-application/ for details.",
+          "additionalProperties": false,
           "properties": {
             "type": {
+              "description": "The metric type to collect.",
               "type": "string",
               "enum": [
                 "histogram",
@@ -51,23 +53,47 @@
                 "type": "string",
                 "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
               }
-            },
-            "buckets": {
-              "description": "The colletor's buckets for the histogram type.",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "number"
+            }
+          },
+          "if": {
+            "properties": {
+              "type": {
+                "const": "histogram"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "buckets": {
+                "description": "The collector's buckets for the histogram type.",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "else": {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "summary"
+                }
               }
             },
-            "objectives": {
-              "description": "The collector's objectives for the summary type.",
-              "type": "object",
-              "minProperties": 1,
-              "additionalProperties": false,
-              "patternProperties": {
-                "^-?[0-9]+(\\.[0-9]+)?$": {
-                  "type": "number"
+            "then": {
+              "properties": {
+                "objectives": {
+                  "description": "The collector's objectives for the summary type. Keys in this map must be a number between 0 and 1.",
+                  "type": "object",
+                  "minProperties": 1,
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^(0(\\.[0-9]+)?|1(\\.0+)?)$": {
+                      "type": "number"
+                    }
+                  }
                 }
               }
             }

--- a/schema.json
+++ b/schema.json
@@ -68,6 +68,7 @@
                 "description": "The collector's buckets for the histogram type.",
                 "type": "array",
                 "minItems": 1,
+                "uniqueItems": true,
                 "items": {
                   "type": "number"
                 }


### PR DESCRIPTION
# Reason for This PR

Added JSON schema.

## Description of Changes

Added JSON schema.

❗ For this one, please review that `collect.objectives` is correct now. It was completely wrong before where it was listed as an array, but it wants a map[float][float] which is kind of weird. I tried to do it.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a JSON schema for the Prometheus Metrics plugin, enhancing configuration validation.
	- Defined key properties such as `address` and `collect` for improved structure and clarity in metrics configuration.
	- Added detailed validation rules for various metric types, ensuring accurate and compliant configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->