### PR TITLE
chore: simplify, modernize (Go 1.26), update deps

### DIFF
--- a/config.go
+++ b/config.go
@@ -122,10 +122,7 @@ func (c *Config) getCollectors() (map[string]*collector, error) {
 			return nil, fmt.Errorf("invalid metric type `%s` for `%s`", m.Type, name)
 		}
 
-		collectors[name] = &collector{
-			col:        promCol,
-			registered: false,
-		}
+		collectors[name] = &collector{col: promCol}
 	}
 
 	return collectors, nil

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/roadrunner-server/endure/v2 v2.6.2
 	github.com/roadrunner-server/errors v1.5.0
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/sys v0.45.0
 )
 
 require (
@@ -28,6 +27,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/grpc v1.81.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,7 +53,9 @@ go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhO
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=
+go.opentelemetry.io/otel/sdk v1.44.0/go.mod h1:Osuydd3Se74nqjAKxid74N5eC+jfEqfTegHRnq58oK0=
 go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRks6si09iEfI=
+go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/go.work.sum
+++ b/go.work.sum
@@ -629,6 +629,7 @@ go.opentelemetry.io/otel v1.36.0 h1:UumtzIklRBY6cI/lllNZlALOF5nNIzJVb16APdvgTXg=
 go.opentelemetry.io/otel v1.36.0/go.mod h1:/TcFMXYjyRNh8khOAO9ybYkqaDBb/70aVwkNML4pP8E=
 go.opentelemetry.io/otel/metric v1.36.0 h1:MoWPKVhQvJ+eeXWHFBOPoBOi20jh6Iq2CcCREuTYufE=
 go.opentelemetry.io/otel/metric v1.36.0/go.mod h1:zC7Ks+yeyJt4xig9DEw9kuUFe5C3zLbVjV2PzT6qzbs=
+go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.36.0 h1:ahxWNuqZjpdiFAyrIoQ4GIiAIhxAunQR6MUoKrsNd4w=
 go.opentelemetry.io/otel/trace v1.36.0/go.mod h1:gQ+OnDZzrybY4k4seLzPAWNwVBBVlF2szhehOBB/tGA=
 go.temporal.io/api v1.24.0 h1:WWjMYSXNh4+T4Y4jq1e/d9yCNnWoHhq4bIwflHY6fic=

--- a/plugin.go
+++ b/plugin.go
@@ -2,8 +2,7 @@ package metrics
 
 import (
 	"context"
-	"crypto/tls"
-	stderr "errors"
+	"errors"
 	"log/slog"
 	"net/http"
 	"sync"
@@ -14,8 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/roadrunner-server/api-go/v6/metrics/v1/metricsV1connect"
 	"github.com/roadrunner-server/endure/v2/dep"
-	"github.com/roadrunner-server/errors"
-	"golang.org/x/sys/cpu"
+	rrerrors "github.com/roadrunner-server/errors"
 )
 
 const (
@@ -62,14 +60,14 @@ type StatProvider interface {
 
 // Init service.
 func (p *Plugin) Init(cfg Configurer, log Logger) error {
-	const op = errors.Op("metrics_plugin_init")
+	const op = rrerrors.Op("metrics_plugin_init")
 	if !cfg.Has(PluginName) {
-		return errors.E(op, errors.Disabled)
+		return rrerrors.E(op, rrerrors.Disabled)
 	}
 
 	err := cfg.UnmarshalKey(PluginName, &p.cfg)
 	if err != nil {
-		return errors.E(op, errors.Disabled, err)
+		return rrerrors.E(op, rrerrors.Disabled, err)
 	}
 
 	p.cfg.InitDefaults()
@@ -80,26 +78,24 @@ func (p *Plugin) Init(cfg Configurer, log Logger) error {
 	// Default
 	err = p.registry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	if err != nil {
-		return errors.E(op, err)
+		return rrerrors.E(op, err)
 	}
 
 	// Default
 	err = p.registry.Register(collectors.NewGoCollector())
 	if err != nil {
-		return errors.E(op, err)
+		return rrerrors.E(op, err)
 	}
 
 	cl, err := p.cfg.getCollectors()
 	if err != nil {
-		return errors.E(op, err)
+		return rrerrors.E(op, err)
 	}
 
 	// Register invocation will be later in the Serve method
 	for k, v := range cl {
 		p.collectors.Store(k, v)
 	}
-
-	p.statProviders = make([]StatProvider, 0, 2)
 
 	return nil
 }
@@ -110,14 +106,13 @@ func (p *Plugin) Register(c prometheus.Collector) error {
 }
 
 // Serve prometheus metrics service.
-func (p *Plugin) Serve() chan error { //nolint:gocyclo
+func (p *Plugin) Serve() chan error {
 	errCh := make(chan error, 1)
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	// register Collected stat providers
-	for i := range p.statProviders {
-		sp := p.statProviders[i]
+	for _, sp := range p.statProviders {
 		for _, c := range sp.MetricsCollector() {
 			err := p.registry.Register(c)
 			if err != nil {
@@ -146,54 +141,6 @@ func (p *Plugin) Serve() chan error { //nolint:gocyclo
 		return true
 	})
 
-	var topCipherSuites []uint16
-	var defaultCipherSuitesTLS13 []uint16
-
-	hasGCMAsmAMD64 := cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ
-	hasGCMAsmARM64 := cpu.ARM64.HasAES && cpu.ARM64.HasPMULL
-	// Keep in sync with crypto/aes/cipher_s390x.go.
-	hasGCMAsmS390X := cpu.S390X.HasAES && cpu.S390X.HasAESCBC && cpu.S390X.HasAESCTR && (cpu.S390X.HasGHASH || cpu.S390X.HasAESGCM)
-
-	hasGCMAsm := hasGCMAsmAMD64 || hasGCMAsmARM64 || hasGCMAsmS390X
-
-	if hasGCMAsm {
-		// If AES-GCM hardware is provided, then prioritize AES-GCM
-		// cipher suites.
-		topCipherSuites = []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-		}
-		defaultCipherSuitesTLS13 = []uint16{
-			tls.TLS_AES_128_GCM_SHA256,
-			tls.TLS_CHACHA20_POLY1305_SHA256,
-			tls.TLS_AES_256_GCM_SHA384,
-		}
-	} else {
-		// Without AES-GCM hardware, we put the ChaCha20-Poly1305
-		// cipher suites first.
-		topCipherSuites = []uint16{
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		}
-		defaultCipherSuitesTLS13 = []uint16{
-			tls.TLS_CHACHA20_POLY1305_SHA256,
-			tls.TLS_AES_128_GCM_SHA256,
-			tls.TLS_AES_256_GCM_SHA384,
-		}
-	}
-
-	DefaultCipherSuites := make([]uint16, 0, 22)
-	DefaultCipherSuites = append(DefaultCipherSuites, topCipherSuites...)
-	DefaultCipherSuites = append(DefaultCipherSuites, defaultCipherSuitesTLS13...)
-
 	p.http = &http.Server{
 		Addr:              p.cfg.Address,
 		Handler:           promhttp.HandlerFor(p.registry, promhttp.HandlerOpts{}),
@@ -202,23 +149,12 @@ func (p *Plugin) Serve() chan error { //nolint:gocyclo
 		MaxHeaderBytes:    maxHeaderSize,
 		ReadHeaderTimeout: time.Minute * 2,
 		WriteTimeout:      time.Minute * 2,
-		TLSConfig: &tls.Config{
-			CurvePreferences: []tls.CurveID{
-				tls.X25519,
-				tls.CurveP256,
-				tls.CurveP384,
-				tls.CurveP521,
-			},
-			CipherSuites: DefaultCipherSuites,
-			MinVersion:   tls.VersionTLS12,
-		},
 	}
 
 	go func() {
 		err := p.http.ListenAndServe()
-		if err != nil && !stderr.Is(err, http.ErrServerClosed) {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
-			return
 		}
 	}()
 
@@ -230,18 +166,14 @@ func (p *Plugin) Weight() uint {
 }
 
 // Stop prometheus metrics service.
-func (p *Plugin) Stop(context.Context) error {
+func (p *Plugin) Stop(ctx context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	if p.http != nil {
-		// timeout is 10 seconds
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		defer cancel()
 		err := p.http.Shutdown(ctx)
 		if err != nil {
-			// Function should be Stop() error
-			p.log.Error("stop error", "error", errors.Errorf("error shutting down the metrics server: error %v", err))
+			return rrerrors.Errorf("error shutting down the metrics server: error %v", err)
 		}
 	}
 	return nil

--- a/rpc.go
+++ b/rpc.go
@@ -2,21 +2,21 @@ package metrics
 
 import (
 	"context"
-	stderr "errors"
+	"errors"
 	"fmt"
 	"log/slog"
 
 	"connectrpc.com/connect"
 	"github.com/prometheus/client_golang/prometheus"
 	metricsV1 "github.com/roadrunner-server/api-go/v6/metrics/v1"
-	"github.com/roadrunner-server/errors"
+	rrerrors "github.com/roadrunner-server/errors"
 )
 
 var (
-	errUndefinedCollector  = stderr.New("undefined collector")
-	errRequiredLabels      = stderr.New("required labels for collector")
-	errUnsupportedOpForCol = stderr.New("collector does not support the requested operation")
-	errUnknownCollectorTyp = stderr.New("unknown collector type")
+	errUndefinedCollector  = errors.New("undefined collector")
+	errRequiredLabels      = errors.New("required labels for collector")
+	errUnsupportedOpForCol = errors.New("collector does not support the requested operation")
+	errUnknownCollectorTyp = errors.New("unknown collector type")
 )
 
 type rpc struct {
@@ -151,7 +151,7 @@ func (r *rpc) Set(_ context.Context, req *connect.Request[metricsV1.SetRequest])
 }
 
 func (r *rpc) Declare(_ context.Context, req *connect.Request[metricsV1.DeclareRequest]) (*connect.Response[metricsV1.Response], error) {
-	const op = errors.Op("metrics_rpc_declare")
+	const op = rrerrors.Op("metrics_rpc_declare")
 
 	nc := req.Msg.GetCollector()
 	r.p.mu.Lock()
@@ -165,11 +165,11 @@ func (r *rpc) Declare(_ context.Context, req *connect.Request[metricsV1.DeclareR
 
 	promCol, err := buildPromCollector(nc)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.E(op, err))
+		return nil, connect.NewError(connect.CodeInvalidArgument, rrerrors.E(op, err))
 	}
 
 	if err := r.p.Register(promCol); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.E(op, err))
+		return nil, connect.NewError(connect.CodeInternal, rrerrors.E(op, err))
 	}
 
 	r.p.collectors.Store(nc.GetName(), &collector{col: promCol, registered: true})
@@ -253,9 +253,12 @@ func buildPromCollector(nc *metricsV1.NamedCollector) (prometheus.Collector, err
 		}
 		return prometheus.NewCounter(opts), nil
 	case metricsV1.CollectorType_COLLECTOR_TYPE_SUMMARY:
-		objectives := make(map[float64]float64, len(col.GetObjectives()))
-		for _, o := range col.GetObjectives() {
-			objectives[o.GetQuantile()] = o.GetError()
+		var objectives map[float64]float64
+		if raw := col.GetObjectives(); len(raw) > 0 {
+			objectives = make(map[float64]float64, len(raw))
+			for _, o := range raw {
+				objectives[o.GetQuantile()] = o.GetError()
+			}
 		}
 		opts := prometheus.SummaryOpts{Name: nc.GetName(), Namespace: col.GetNamespace(), Subsystem: col.GetSubsystem(), Help: col.GetHelp(), Objectives: objectives}
 		if len(col.GetLabels()) != 0 {

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -157,7 +157,9 @@ go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhO
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=
+go.opentelemetry.io/otel/sdk v1.44.0/go.mod h1:Osuydd3Se74nqjAKxid74N5eC+jfEqfTegHRnq58oK0=
 go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRks6si09iEfI=
+go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=


### PR DESCRIPTION
## Applied fixes

**S (Simplify) — 2 applied**
- Removed dead ~45-line TLS cipher-suite block from `Serve` (`ListenAndServe` never uses TLS config; Go ignores `CipherSuites` for TLS 1.3 regardless). Also removes `make([]uint16,0,22)+append` that built the dead slice.
- Dropped arbitrary `make([]StatProvider, 0, 2)` pre-allocation in `Init`.

**M (Modern Go) — 3 applied**
- `range-over-value` for `statProviders` loop (Go 1.22, `plugin.go:119`).
- Dropped `stderr "errors"` import alias in `plugin.go` and `rpc.go`; stdlib `errors` used directly for `errors.New`/`errors.Is`, roadrunner errors qualified as `rrerrors`.
- Objectives nil guard in `buildPromCollector`: pass `nil` map (not empty allocated map) to `prometheus.SummaryOpts` when no objectives are configured (`rpc.go:256`).

**R (Review/bugs) — 2 applied**
- `Stop` now passes the received `ctx` directly to `http.Shutdown` instead of creating `context.WithTimeout(context.Background(), 10s)`, honouring the framework-supplied deadline (`plugin.go:233`).
- `Stop` now returns the shutdown error instead of logging it and returning `nil` (`plugin.go:244`).

**Config — 1 applied**
- Omit `registered: false` zero-value field in `collector` struct literals (`config.go:125`).

## Deps

Root `go.mod` and `tests/go.mod` updated via `go get -u all && go mod tidy`; `go work sync` run at workspace root.

